### PR TITLE
Fixes SCSS compile issue with @extend .pull-md-right

### DIFF
--- a/assets/scss/includes/_navbar.scss
+++ b/assets/scss/includes/_navbar.scss
@@ -6,7 +6,7 @@
     }
   }
   .search-form {
-    @extend .pull-md-right;
+    @extend .float-md-right;
     @include media-breakpoint-up(md) {
       .input-group {
         max-width: 300px;


### PR DESCRIPTION
Changes extending class .pull-md-right to .float-md-right. Pull right/left classes have been removed from recent Bootstrap v4 and introduces a breaking change in theme.

See https://v4-alpha.getbootstrap.com/migration/#utilities for more info.